### PR TITLE
Mp 46 as a mentee i can view a catalogue of pathways

### DIFF
--- a/app/controllers/pathways_controller.rb
+++ b/app/controllers/pathways_controller.rb
@@ -1,5 +1,5 @@
 class PathwaysController < ApplicationController
-  before_action :authenticate_user!
+  before_action :authenticate_user!, except: %i[index show]
   before_action :set_pathway, only: %i[show edit update destroy]
   before_action :mentor?, only: %i[new create edit update destroy]
   def index

--- a/app/controllers/pathways_controller.rb
+++ b/app/controllers/pathways_controller.rb
@@ -1,5 +1,6 @@
 class PathwaysController < ApplicationController
   before_action :set_pathway, only: %i[show edit update destroy]
+  before_action :mentor?, only: %i[new create edit update destroy]
 
   def index
     @pathways = Pathway.all
@@ -43,5 +44,11 @@ class PathwaysController < ApplicationController
 
   def set_pathway
     @pathway = Pathway.find(params[:id])
+  end
+
+  def mentor?
+    unless current_user.mentor?
+      redirect_to root_path
+    end
   end
 end

--- a/app/controllers/pathways_controller.rb
+++ b/app/controllers/pathways_controller.rb
@@ -1,7 +1,7 @@
 class PathwaysController < ApplicationController
+  before_action :authenticate_user!
   before_action :set_pathway, only: %i[show edit update destroy]
   before_action :mentor?, only: %i[new create edit update destroy]
-
   def index
     @pathways = Pathway.all
   end

--- a/app/views/pathways/_pathway.html.erb
+++ b/app/views/pathways/_pathway.html.erb
@@ -6,5 +6,5 @@
         <p><%= pathway.difficulty %></p>
       <% end %>
     </div>
-    <%= link_to "Delete", pathway_path(pathway), data: { turbo_method: :delete, turbo_confirm: "Are you sure?" } %>
+    <%= link_to "Delete", pathway_path(pathway), data: { turbo_method: :delete, turbo_confirm: "Are you sure?" } if current_user.mentor? %>
   </div>

--- a/app/views/pathways/_pathway.html.erb
+++ b/app/views/pathways/_pathway.html.erb
@@ -6,5 +6,5 @@
         <p><%= pathway.difficulty %></p>
       <% end %>
     </div>
-    <%= link_to "Delete", pathway_path(pathway), data: { turbo_method: :delete, turbo_confirm: "Are you sure?" } if current_user.mentor? %>
+    <%= link_to "Delete", pathway_path(pathway), data: { turbo_method: :delete, turbo_confirm: "Are you sure?" } if user_signed_in? && current_user.mentor? %>
   </div>

--- a/app/views/pathways/index.html.erb
+++ b/app/views/pathways/index.html.erb
@@ -1,7 +1,7 @@
 <div class="mt-16 p-12">
   <h1 class="mb-5 font-bold">This is Pathway #Index Page</h1>
   <div class="mb-5">
-    <%= link_to "New", new_pathway_path, class: "border rounded-lg bg-blue-700 text-white py-2 px-3" if current_user.mentor? %>
+    <%= link_to "New", new_pathway_path, class: "border rounded-lg bg-blue-700 text-white py-2 px-3" if user_signed_in? && current_user.mentor? %>
   </div>
   <% if @pathways %>
     <% @pathways.each do |pathway| %>

--- a/app/views/pathways/index.html.erb
+++ b/app/views/pathways/index.html.erb
@@ -1,7 +1,7 @@
 <div class="mt-16 p-12">
   <h1 class="mb-5 font-bold">This is Pathway #Index Page</h1>
   <div class="mb-5">
-    <%= link_to "New", new_pathway_path, class: "border rounded-lg bg-blue-700 text-white py-2 px-3" %>
+    <%= link_to "New", new_pathway_path, class: "border rounded-lg bg-blue-700 text-white py-2 px-3" if current_user.mentor? %>
   </div>
   <% if @pathways %>
     <% @pathways.each do |pathway| %>

--- a/app/views/pathways/show.html.erb
+++ b/app/views/pathways/show.html.erb
@@ -2,7 +2,7 @@
   <%= link_to "Back", pathways_path %>
   <h1 class="font-bold">This is Pathway #Show page</h1>
   <div class="my-5">
-    <%= link_to "Edit", edit_pathway_path(@pathway), class: "border rounded-lg bg-blue-700 text-white py-2 px-3" if current_user.mentor? %>
+    <%= link_to "Edit", edit_pathway_path(@pathway), class: "border rounded-lg bg-blue-700 text-white py-2 px-3" if user_signed_in? && current_user.mentor? %>
   </div>
   <h1 class="font-bold">This is Pathway</h1>
   <div class="border">

--- a/app/views/pathways/show.html.erb
+++ b/app/views/pathways/show.html.erb
@@ -2,7 +2,7 @@
   <%= link_to "Back", pathways_path %>
   <h1 class="font-bold">This is Pathway #Show page</h1>
   <div class="my-5">
-    <%= link_to "Edit", edit_pathway_path(@pathway), class: "border rounded-lg bg-blue-700 text-white py-2 px-3" %>
+    <%= link_to "Edit", edit_pathway_path(@pathway), class: "border rounded-lg bg-blue-700 text-white py-2 px-3" if current_user.mentor? %>
   </div>
   <h1 class="font-bold">This is Pathway</h1>
   <div class="border">


### PR DESCRIPTION
Added authentication for create, edit and destroy actions in pathways controller, will redirect to log in if user is not logged in, or user is not a mentor.
Pathway views for mentees are the same as for mentors, only without create, edit and destroy pathways
Users can access pathways view and show pages if not logged in
Needs testing!
