### PR TITLE
fix: make pathway difficulty an enum [MP-60]

### DIFF
--- a/app/models/pathway.rb
+++ b/app/models/pathway.rb
@@ -1,7 +1,7 @@
 class Pathway < ApplicationRecord
   validates :title, presence: true, format: {with: /[a-zA-Z0-9_-]/}, length: {maximum: 50}
   validates :details, presence: true, length: {maximum: 1500}
-  validates :difficulty, presence: true, length: {minimum: 3}
+  validates :difficulty, presence: true
 
   belongs_to :user
   has_many :path_challenges

--- a/app/models/pathway.rb
+++ b/app/models/pathway.rb
@@ -3,6 +3,8 @@ class Pathway < ApplicationRecord
   validates :details, presence: true, length: {maximum: 1500}
   validates :difficulty, presence: true
 
+  enum difficulty: {beginner: 0, intermediate: 1, advanced: 2}
+
   belongs_to :user
   has_many :path_challenges
   has_many :challenges, through: :path_challenges

--- a/app/views/pathways/_form.html.erb
+++ b/app/views/pathways/_form.html.erb
@@ -10,7 +10,7 @@
     </div>
     <div class="my-3">
       <p>Difficulty</p>
-      <%= f.input :difficulty, collection: [ "beginner", "intermediate", "professional", "advanced" ], label: false %>
+      <%= f.input :difficulty, collection: [ "beginner", "intermediate", "advanced" ], label: false %>
     </div>
     <%= f.submit pathway.nil? ? "Save" : "Create", class: "border rounded mt-3 py-2 px-3 bg-blue-700 text-white" %>
   <% end %>

--- a/db/migrate/20221112175149_change_data_type_for_pathway.rb
+++ b/db/migrate/20221112175149_change_data_type_for_pathway.rb
@@ -1,0 +1,6 @@
+class ChangeDataTypeForPathway < ActiveRecord::Migration[7.0]
+  def change
+    remove_column :pathways, :difficulty
+    add_column :pathways, :difficulty, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_11_06_184532) do
+ActiveRecord::Schema[7.0].define(version: 2022_11_12_175149) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -48,6 +48,10 @@ ActiveRecord::Schema[7.0].define(version: 2022_11_06_184532) do
     t.bigint "user_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.datetime "completed"
+    t.text "notes"
+    t.text "feedback"
+    t.integer "rating"
     t.index ["user_id"], name: "index_challenges_on_user_id"
   end
 
@@ -64,10 +68,10 @@ ActiveRecord::Schema[7.0].define(version: 2022_11_06_184532) do
   create_table "pathways", force: :cascade do |t|
     t.string "title"
     t.text "details"
-    t.string "difficulty"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "user_id", null: false
+    t.integer "difficulty"
     t.index ["user_id"], name: "index_pathways_on_user_id"
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -8,7 +8,7 @@ puts "-----------------"
 user = User.create!(first_name: "Ben", last_name: "Simpson", email: "ben@ben.com", password: "Testpassword1!", role: :mentor)
 puts "One user created"
 
-pathway = Pathway.create!(title: "Test 1", details: "This is a test pathway", difficulty: "beginner", user_id: user.id)
+pathway = Pathway.create!(title: "Test 1", details: "This is a test pathway", difficulty: :beginner, user_id: user.id)
 puts "One pathway created"
 
 challenge = Challenge.create!(title: "Database number 1", details: "This is a question that needs answers regarding the database", user_id: User.last.id)

--- a/spec/factories/pathways.rb
+++ b/spec/factories/pathways.rb
@@ -2,7 +2,7 @@ FactoryBot.define do
   factory :pathway do
     title { "Pathway One" }
     details { "Lorem ipsum dolor sit amet, officia excepteur ex fugiat reprehenderit enim labore culpa sint ad nisi Lorem pariatur mollit ex esse exercitation amet. Nisi anim cupidatat excepteur officia. Reprehenderit nostrud nostrud ipsum Lorem est aliquip amet voluptate voluptate dolor minim nulla est proident. Nostrud officia pariatur ut officia. Sit irure elit esse ea nulla sunt ex occaecat reprehenderit commodo officia dolor Lorem duis laboris cupidatat officia voluptate. Culpa proident adipisicing id nulla nisi laboris ex in Lorem sunt duis officia eiusmod. Aliqua reprehenderit commodo ex non excepteur duis sunt velit enim. Voluptate laboris sint cupidatat ullamco ut ea consectetur et est culpa et culpa duis." }
-    difficulty { :beginer }
+    difficulty { :beginner }
     user { association :user }
   end
 end

--- a/test/fixtures/pathways.yml
+++ b/test/fixtures/pathways.yml
@@ -3,9 +3,9 @@
 one:
   title: MyString
   details: MyText
-  difficulty: MyString
+  difficulty: Integer
 
 two:
   title: MyString
   details: MyText
-  difficulty: MyString
+  difficulty: Integer


### PR DESCRIPTION
- limited to three difficulties, beginner, intermediate and advanced (removed professional but can add back in, @hykim103 was it agreed to have four?)
- unsure what fixtures > pathways did, but changed difficulty from MyString to Integer
- everyone will need to db:migrate after pulling

