### PR TITLE
feat: comments with markdown support [MP-47][MP-107]

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,10 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 ruby "3.1.2"
 
+# for Markdown support
+gem "redcarpet"
+gem "coderay"
+
 # Bundle edge Rails instead: gem "rails", github: "rails/rails", branch: "main"
 gem "rails", "~> 7.0.3"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -98,6 +98,7 @@ GEM
     cloudinary (1.23.0)
       aws_cf_signer
       rest-client (>= 2.0.0)
+    coderay (1.1.3)
     concurrent-ruby (1.1.10)
     crass (1.0.6)
     debug (1.6.2)
@@ -216,6 +217,7 @@ GEM
       zeitwerk (~> 2.5)
     rainbow (3.1.1)
     rake (13.0.6)
+    redcarpet (3.5.1)
     regexp_parser (2.5.0)
     reline (0.3.1)
       io-console (~> 0.5)
@@ -334,6 +336,7 @@ DEPENDENCIES
   bootsnap
   capybara
   cloudinary
+  coderay
   debug
   devise
   factory_bot_rails
@@ -344,6 +347,7 @@ DEPENDENCIES
   pg
   puma (~> 5.0)
   rails (~> 7.0.3)
+  redcarpet
   rspec-rails (~> 6.0, >= 6.0.1)
   rubocop-rails
   rubocop-rspec

--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -1,4 +1,15 @@
 @tailwind base;
+
+/* h1 {
+  @apply text-4xl;
+}
+h2 {
+  @apply text-xl;
+}
+h3 {
+  @apply text-lg;
+} */
+
 @tailwind components;
 @tailwind utilities;
 
@@ -6,7 +17,7 @@
 
 @layer components {
   .btn-primary {
-    @apply py-2 px-4 bg-blue-200;
+    @apply px-4 py-2 bg-blue-200;
   }
 }
 

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,0 +1,2 @@
+class CommentsController < ApplicationController
+end

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,2 +1,56 @@
 class CommentsController < ApplicationController
+  before_action :set_comment, only: %i[edit update destroy]
+  before_action :set_user_challenge, only: %i[new create edit]
+
+  def comment
+    @comment = Comment.new
+  end
+
+  def create
+    @comment = current_user.comments.build(comment_params)
+    @comment.user = current_user
+    @comment.user_challenge = @user_challenge
+    if @comment.save
+      respond_to do |format|
+        format.html { redirect_to user_challenge_path(@user_challenge) }
+        format.turbo_stream
+      end
+    else
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  def edit
+  end
+
+  def update
+    if @comment.update(comment_params)
+      redirect_to user_challenge_path(@comment.user_challenge)
+    else
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    @comment.destroy
+
+    respond_to do |format|
+      format.html { redirect_to user_challenge_path(@comment.user_challenge), status: :see_other }
+      format.turbo_stream
+    end
+  end
+
+  private
+
+  def comment_params
+    params.require(:comment).permit(:comment)
+  end
+
+  def set_comment
+    @comment = current_user.comments.find(params[:id])
+  end
+
+  def set_user_challenge
+    @user_challenge = current_user.user_challenges.find(params[:user_challenge_id])
+  end
 end

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -8,7 +8,6 @@ class CommentsController < ApplicationController
 
   def create
     @comment = current_user.comments.build(comment_params)
-    @comment.user = current_user
     @comment.user_challenge = @user_challenge
     if @comment.save
       respond_to do |format|

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -46,10 +46,10 @@ class CommentsController < ApplicationController
   end
 
   def set_comment
-    @comment = current_user.comments.find(params[:id])
+    @comment = current_user.comments.find_by(id: params[:id])
   end
 
   def set_user_challenge
-    @user_challenge = current_user.user_challenges.find(params[:user_challenge_id])
+    @user_challenge = current_user.user_challenges.find_by(id: params[:user_challenge_id])
   end
 end

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -2,7 +2,7 @@ class CommentsController < ApplicationController
   before_action :set_comment, only: %i[edit update destroy]
   before_action :set_user_challenge, only: %i[new create edit]
 
-  def comment
+  def new
     @comment = Comment.new
   end
 
@@ -43,7 +43,7 @@ class CommentsController < ApplicationController
   private
 
   def comment_params
-    params.require(:comment).permit(:comment)
+    params.require(:comment).permit(:message)
   end
 
   def set_comment

--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -8,7 +8,6 @@ class NotesController < ApplicationController
 
   def create
     @note = current_user.notes.build(note_params)
-    @note.user = current_user
     @note.user_challenge = @user_challenge
     if @note.save
       respond_to do |format|

--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -46,10 +46,10 @@ class NotesController < ApplicationController
   end
 
   def set_user_challenge
-    @user_challenge = current_user.user_challenges.find(params[:user_challenge_id])
+    @user_challenge = current_user.user_challenges.find_by(id: params[:user_challenge_id])
   end
 
   def set_note
-    @note = current_user.notes.find(params[:id])
+    @note = current_user.notes.find_by(id: params[:id])
   end
 end

--- a/app/controllers/user_challenges_controller.rb
+++ b/app/controllers/user_challenges_controller.rb
@@ -31,7 +31,7 @@ class UserChallengesController < ApplicationController
   private
 
   def user_challenge_params
-    params.require(:user_challenge).permit(:challenge_id, :notes, :feedback, :rating)
+    params.require(:user_challenge).permit(:challenge_id, :notes, :comments, :feedback, :rating)
   end
 
   def set_user

--- a/app/controllers/user_challenges_controller.rb
+++ b/app/controllers/user_challenges_controller.rb
@@ -4,6 +4,7 @@ class UserChallengesController < ApplicationController
 
   def show
     @notes = @user_challenge.notes.reverse
+    @comments = @user_challenge.comments.reverse
   end
 
   def new
@@ -15,7 +16,6 @@ class UserChallengesController < ApplicationController
     @user_challenge.user = @user
     @user_challenge.completed = false
     if @user_challenge.save
-      # We should add where to redirect
     else
       render :new, status: :unprocessable_entity
     end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,19 @@
 module ApplicationHelper
+  class CodeRayify < Redcarpet::Render::HTML
+    def block_code(code, language)
+      CodeRay.scan(code, language).div
+    end
+  end
+
+  def markdown(text)
+    coderayified = CodeRayify.new(filter_html: true, hard_wrap: true)
+    options = {
+      fenced_code_blocks: true,
+      no_intra_emphasis: true,
+      autolink: true,
+      lax_html_blocks: true
+    }
+    markdown_to_html = Redcarpet::Markdown.new(coderayified, options)
+    markdown_to_html.render(text).html_safe
+  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,19 +1,2 @@
 module ApplicationHelper
-  class CodeRayify < Redcarpet::Render::HTML
-    def block_code(code, language)
-      CodeRay.scan(code, language).div
-    end
-  end
-
-  def markdown(text)
-    coderayified = CodeRayify.new(filter_html: true, hard_wrap: true)
-    options = {
-      fenced_code_blocks: true,
-      no_intra_emphasis: true,
-      autolink: true,
-      lax_html_blocks: true
-    }
-    markdown_to_html = Redcarpet::Markdown.new(coderayified, options)
-    markdown_to_html.render(text).html_safe
-  end
 end

--- a/app/helpers/comments_helper.rb
+++ b/app/helpers/comments_helper.rb
@@ -1,0 +1,2 @@
+module CommentsHelper
+end

--- a/app/helpers/comments_helper.rb
+++ b/app/helpers/comments_helper.rb
@@ -1,2 +1,19 @@
 module CommentsHelper
+  class CodeRayify < Redcarpet::Render::HTML
+    def block_code(code, language)
+      CodeRay.scan(code, language).div
+    end
+  end
+
+  def markdown(text)
+    coderayified = CodeRayify.new(filter_html: true, hard_wrap: true)
+    options = {
+      fenced_code_blocks: true,
+      no_intra_emphasis: true,
+      autolink: true,
+      lax_html_blocks: true
+    }
+    markdown_to_html = Redcarpet::Markdown.new(coderayified, options)
+    markdown_to_html.render(text).html_safe
+  end
 end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,9 +1,6 @@
 class Comment < ApplicationRecord
-  validates :message,
-    length: {maximum: 1500},
-    presence: true
+  validates :message, presence: true, length: {maximum: 1500}
   belongs_to :user_challenge
   belongs_to :user
-
   broadcasts_to ->(comment) { "comments" }, inserts_by: :prepend
 end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -4,4 +4,6 @@ class Comment < ApplicationRecord
     presence: true
   belongs_to :user_challenge
   belongs_to :user
+
+  broadcasts_to ->(comment) { "comments" }, inserts_by: :prepend
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,6 +8,7 @@ class User < ApplicationRecord
   has_many :pathways, dependent: :destroy
   has_many :user_challenges, dependent: :destroy
   has_many :notes, dependent: :destroy
+  has_many :comments, dependent: :destroy
   has_many :user_pathways, dependent: :destroy
 
   enum :role, {mentor: 0, mentee: 1}

--- a/app/views/challenges/show.html.erb
+++ b/app/views/challenges/show.html.erb
@@ -1,7 +1,5 @@
-
-
 <div class='flex flex-col justify-between h-full p-12'>
   <%= link_to "Back", pathway_path(@pathway) %>
-  <h1 class='font-bold text-lg text-center'><%= @challenge.title %></h1>
+  <h1 class='text-lg font-bold text-center'><%= @challenge.title %></h1>
   <h3 class='p-1'><%= @challenge.details %></h3>
 </div>

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -1,7 +1,7 @@
 <%= turbo_frame_tag comment do %>
   <div class="flex flex-col mb-4">
     <div class="p-2 mb-1 border break-word w-100">
-      <%= comment.message %>
+      <%= markdown(comment.message) %>
     </div>
     <div class="flex">
       <%= link_to "Edit", edit_user_challenge_comment_path(comment.user_challenge, comment), class: "border px-3" %>

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -1,0 +1,11 @@
+<%= turbo_frame_tag comment do %>
+  <div class="flex flex-col mb-4">
+    <div class="p-2 mb-1 border break-word w-100">
+      <%= comment.message %>
+    </div>
+    <div class="flex">
+      <%= link_to "Edit", edit_user_challenge_comment_path(comment.user_challenge, comment), class: "border px-3" %>
+      <%= link_to "Delete", comment_path(comment), data: { turbo_method: :delete, turbo_confirm: "Are you sure?" }, class: "border px-3 ml-1" %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/comments/_form.html.erb
+++ b/app/views/comments/_form.html.erb
@@ -1,0 +1,9 @@
+<div class="mt-3">
+  <%= simple_form_for [user_challenge, comment] do |f| %>
+    <%= f.input :message, label: false %>
+    <div>
+      <%= link_to "Cancel", user_challenge_path(user_challenge), class: "border p-2" %>
+      <%= f.submit comment.id.nil? ? "Create" : "Save", class: "border p-2" %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/comments/create.turbo_stream.erb
+++ b/app/views/comments/create.turbo_stream.erb
@@ -1,0 +1,2 @@
+<%= turbo_stream.prepend "comments", @comment %>
+<%= turbo_stream.update Comment.new, "" %>

--- a/app/views/comments/destroy.turbo_stream.erb
+++ b/app/views/comments/destroy.turbo_stream.erb
@@ -1,0 +1,1 @@
+<%= turbo_stream.remove @comment %>

--- a/app/views/comments/edit.html.erb
+++ b/app/views/comments/edit.html.erb
@@ -1,0 +1,6 @@
+<div>
+  <h1 class="text-4xl font-bold">Comments#edit</h1>
+  <%= turbo_frame_tag @comment do %>
+    <%= render "form", user_challenge: @user_challenge, comment: @comment %>
+  <% end %>
+</div>

--- a/app/views/comments/new.html.erb
+++ b/app/views/comments/new.html.erb
@@ -1,0 +1,7 @@
+<div>
+  <h1 class="text-4xl font-bold">Comments#new</h1>
+
+  <%= turbo_frame_tag @comment do %>
+    <%= render "form", user_challenge: @user_challenge, comment: @comment %>
+  <% end %>
+</div>

--- a/app/views/user_challenges/show.html.erb
+++ b/app/views/user_challenges/show.html.erb
@@ -8,7 +8,6 @@
       <h3 class='p-1'><%= @user_challenge.challenge.details %></h3>
       <p><%= @user_challenge.rating %></p>
 
-
       <div class="">
         <%= link_to "New comment",
                     new_user_challenge_comment_path(@user_challenge),

--- a/app/views/user_challenges/show.html.erb
+++ b/app/views/user_challenges/show.html.erb
@@ -1,21 +1,37 @@
-<div class="mt-16 p-12">
+<div class="p-12 mt-16">
   <h1>This is User_Challenge #Show page</h1>
 
   <div class='flex'>
-    <div class='flex flex-col justify-between h-full p-12 w-3/4'>
+    <div class='flex flex-col justify-between w-3/4 h-full p-12'>
       <%= link_to "Back", profile_user_pathway_path(current_user.profile, @user_challenge.user_pathway) %>
-      <h1 class='font-bold text-lg text-center'><%= @user_challenge.challenge.title %></h1>
+      <h1 class='text-lg font-bold text-center'><%= @user_challenge.challenge.title %></h1>
       <h3 class='p-1'><%= @user_challenge.challenge.details %></h3>
       <p><%= @user_challenge.rating %></p>
 
-      <%# Placeholder input box %>
-          Answer
-          <input type="text" name="Answer" id="" class='h-24'>
-      <%# Placeholder input box %>
 
-      <p class='font-medium	italic'><%= @user_challenge.comments.count %> Comments</p>
+      <div class="">
+        <%= link_to "New comment",
+                    new_user_challenge_comment_path(@user_challenge),
+                    data: { turbo_frame: dom_id(Comment.new) },
+                    class: "border px-3 mb-3" %>
+
+        <%= turbo_frame_tag Comment.new %>
+
+        <div class='mt-3'>
+          <%= turbo_frame_tag "comments" do %>
+            <% if !@comments.nil? %>
+              <% @comments.each do |comment| %>
+                <%= render "comments/comment", comment: comment %>
+              <% end %>
+            <% end %>
+          <% end %>
+        </div>
+      </div>
+
+      <p class='italic font-medium'><%= @user_challenge.comments.count %> Comments</p>
     </div>
-    <div class='h-full p-12 w-1/4'>
+
+    <div class='w-1/4 h-full p-12'>
       <%= link_to "New note",
                   new_user_challenge_note_path(@user_challenge),
                   data: { turbo_frame: dom_id(Note.new) },

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,8 +1,6 @@
 Rails.application.routes.draw do
   devise_for :users
-  # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
-  # Defines the root path route ("/")
-  # root "articles#index"
+
   get "/user_pathways/:id/signup", to: "user_pathways#signup", as: "signup"
   root "pages#home"
   resources :pathways do
@@ -19,7 +17,7 @@ Rails.application.routes.draw do
 
   resources :user_challenges, only: %w[index show] do
     resources :notes, only: %w[new create edit update]
-    resources :comments, only: %w[create update]
+    resources :comments, only: %w[new create edit update]
   end
   resources :notes, only: :destroy
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,15 +13,13 @@ Rails.application.routes.draw do
 
   resources :profiles, only: %w[show edit] do
     resources :user_pathways, only: %w[show] do
-      resources :user_challenges, only: %w[show] do
-        resources :comments, only: %w[create update]
-      end
+      resources :user_challenges, only: %w[show]
     end
   end
 
-  # Created this routes to test out Notes
   resources :user_challenges, only: %w[index show] do
     resources :notes, only: %w[new create edit update]
+    resources :comments, only: %w[create update]
   end
   resources :notes, only: :destroy
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,9 +20,9 @@ Rails.application.routes.draw do
     resources :comments, only: %w[new create edit update]
   end
   resources :notes, only: :destroy
+  resources :comments, only: :destroy
 
   resources :challenges, only: %w[destroy]
   resources :user_challenges, only: %w[destroy]
   resources :path_challenges, only: %w[destroy]
-  resources :comments, only: %(destroy)
 end

--- a/spec/factories/comments.rb
+++ b/spec/factories/comments.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :comment do
     message { "MyText" }
-    user_challenge { create(:user_challenge) }
     user { create(:user) }
+    user_challenge { create(:user_challenge, user: user) }
   end
 end

--- a/spec/helpers/comments_helper_spec.rb
+++ b/spec/helpers/comments_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the CommentsHelper. For example:
+#
+# describe CommentsHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe CommentsHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Comment, type: :model do
 
   describe "comment validity" do
     it "is valid with valid attributes" do
-      comment = build(:comment)
+      comment = build(:comment, message: "valid message")
       expect(comment).to be_valid
     end
 

--- a/spec/requests/comments_spec.rb
+++ b/spec/requests/comments_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe "Comments", type: :request do
+  describe "GET /index" do
+    pending "add some examples (or delete) #{__FILE__}"
+  end
+end


### PR DESCRIPTION
I used a library called Redcarpet to convert Markdown text to HTML. In the application_helper.rb file, you'll see a markdown method that takes in some text, and then uses Redcarpet's Markdown class to convert it to HTML, using the CodeRayify class to handle code blocks.

**Features:**
- comments can be added, edited and destroyed with Turbo; heavily inspired by hykim's work!
- user assumed to know how to write markdown; no built in icons like in GitHub comments. 

**To be Done**
- have yet to implement **Capybara** testing
- everyone will need to `bundle install` after

<img width="914" alt="Screenshot 2023-01-10 at 16 03 10" src="https://user-images.githubusercontent.com/93719632/211601298-0fa961fc-86d1-453c-8553-8257dd924c43.png">
